### PR TITLE
メモダイアログに選択中のクリップボード名を表示

### DIFF
--- a/src/components/MemoDialog.tsx
+++ b/src/components/MemoDialog.tsx
@@ -3,9 +3,10 @@ import { type FC, useState, useRef, useEffect, type KeyboardEvent } from "react"
 interface MemoDialogProps {
   onConfirm: (memo: string) => void
   onCancel: () => void
+  clipboardName?: string
 }
 
-const MemoDialog: FC<MemoDialogProps> = ({ onConfirm, onCancel }) => {
+const MemoDialog: FC<MemoDialogProps> = ({ onConfirm, onCancel, clipboardName }) => {
   const [memo, setMemo] = useState("")
   const [isComposing, setIsComposing] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -69,6 +70,22 @@ const MemoDialog: FC<MemoDialogProps> = ({ onConfirm, onCancel }) => {
         }}>
           メモを追加（任意）
         </h3>
+
+        {clipboardName && (
+          <div style={{
+            marginBottom: '12px',
+            padding: '8px 12px',
+            backgroundColor: '#f5f5f5',
+            borderRadius: '4px',
+            fontSize: '14px',
+            color: '#333'
+          }}>
+            <span style={{ color: '#666', fontSize: '12px' }}>クリップ先:</span>
+            <span style={{ marginLeft: '8px', fontWeight: '500' }}>
+              📋 {clipboardName}
+            </span>
+          </div>
+        )}
 
         <textarea
           ref={textareaRef}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -21,6 +21,7 @@ function IndexPopup() {
   const [selectedClipboardId, setSelectedClipboardId] = useState<string | undefined>()
   const [showMemoDialog, setShowMemoDialog] = useState(false)
   const [pendingClipDatabaseId, setPendingClipDatabaseId] = useState<string | undefined>()
+  const [pendingClipboardName, setPendingClipboardName] = useState<string | undefined>()
 
   useEffect(() => {
     initializeAndLoadData()
@@ -101,6 +102,7 @@ function IndexPopup() {
     // クリップボードが1つだけの場合は自動選択してメモダイアログを表示
     if (clipboards.length === 1) {
       setPendingClipDatabaseId(clipboards[0].notionDatabaseId)
+      setPendingClipboardName(clipboards[0].name)
       setShowMemoDialog(true)
       return
     }
@@ -110,8 +112,12 @@ function IndexPopup() {
   }
 
   const handleSelectClipboard = async (databaseId: string) => {
+    // 選択されたクリップボードの名前を取得
+    const selectedClipboard = clipboards.find(cb => cb.notionDatabaseId === databaseId)
+
     // メモダイアログを表示
     setPendingClipDatabaseId(databaseId)
+    setPendingClipboardName(selectedClipboard?.name)
     setShowMemoDialog(true)
   }
 
@@ -120,12 +126,14 @@ function IndexPopup() {
     if (pendingClipDatabaseId) {
       await performClip(pendingClipDatabaseId, memo)
       setPendingClipDatabaseId(undefined)
+      setPendingClipboardName(undefined)
     }
   }
 
   const handleMemoCancel = () => {
     setShowMemoDialog(false)
     setPendingClipDatabaseId(undefined)
+    setPendingClipboardName(undefined)
   }
 
   const performClip = async (databaseId: string, memo?: string) => {
@@ -218,6 +226,7 @@ function IndexPopup() {
         <MemoDialog
           onConfirm={handleMemoConfirm}
           onCancel={handleMemoCancel}
+          clipboardName={pendingClipboardName}
         />
       )}
     </>


### PR DESCRIPTION
## 概要

クリップ追加時のメモ入力ダイアログに、現在選択されているクリップボード名を表示する機能を追加しました。

## 背景

複数クリップボードが作成されている場合は選択ダイアログが表示されますが、クリップボードを1つしか作成していない場合や、選択後にメモ入力画面に遷移した際に、自分がどこにクリップしようとしているのか分かりにくい状態でした。

## 変更内容

### MemoDialog.tsx
- \`clipboardName\`プロパティを追加
- メモ入力エリアの上部に、選択されたクリップボード名を表示する情報ボックスを追加
- 表示形式: グレーの背景に「クリップ先: 📋 クリップボード名」

### popup.tsx
- \`pendingClipboardName\`状態を追加
- クリップボードを1つだけ選択した場合（自動選択時）にクリップボード名を設定
- 複数のクリップボードから選択した場合に、選択されたクリップボードの名前を取得して設定
- メモダイアログに\`clipboardName\`プロップを渡す
- ダイアログ確定/キャンセル時に状態をクリア

## テスト

- [x] クリップボードが1つの場合、自動選択でクリップボード名が表示される
- [x] 複数のクリップボードから選択した場合、選択したクリップボード名が表示される
- [x] メモ確定後、状態が正しくクリアされる
- [x] メモキャンセル後、状態が正しくクリアされる

## UX改善

- ユーザーは常に「今どこにクリップしようとしているのか」を確認できる
- クリップボードが1つの場合でも、どこにクリップするか明確に表示される
- 複数クリップボードから選択した場合も、選択内容を確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)