### PR TITLE
refactor: CSS管理をnotion-custom.cssに一本化し、ワークスペース切り替えボタンの非表示を削除

### DIFF
--- a/src/contents/notion-simplify.ts
+++ b/src/contents/notion-simplify.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PlasmoCSConfig } from "plasmo"
+import customCssText from "data-text:~styles/notion-custom.css"
 
 // www.notion.soでのみ実行
 export const config: PlasmoCSConfig = {
@@ -14,26 +15,6 @@ export const config: PlasmoCSConfig = {
 
 const STYLE_ELEMENT_ID = 'raku-notion-simplify-styles'
 const STORAGE_KEY = 'raku-ui-simplify-config'
-
-// CSS定義（notion-custom.cssの内容をインライン化）
-const CUSTOM_CSS = `
-/* Notion UI Simplification Styles */
-a:has(svg.aiFace) { display: none !important; }
-div[style*="min-height: 27px"]:has(svg.inbox) { display: none !important; }
-div[style*="min-height: 27px"]:has(svg.home) { display: none !important; }
-div[style*="min-height: 27px"]:has(svg.magnifyingGlass) { display: none !important; }
-div[style*="min-height: 27px"]:has(svg.gear) { display: none !important; }
-div[style*="min-height: 24px"]:has(svg.templates) { display: none !important; }
-div[style*="min-height: 24px"]:has(svg.trash) { display: none !important; }
-.notion-sidebar-switcher { visibility: collapse; }
-.notion-outliner-shared-header-container { visibility: collapse; }
-.notion-ai-button { visibility: collapse; }
-.notion-collection-automation-edit-view { display: none !important; }
-.notion-topbar-share-menu { display: none !important; }
-.notion-topbar-favorite-button { display: none !important; }
-.notion-topbar-more-button { display: none !important; }
-div[style*="height: 28px"][style*="width: 28px"][style*="padding: 0px"] { display: none !important; }
-`
 
 /**
  * CSSを注入してNotionのUIを簡略化
@@ -48,7 +29,7 @@ function injectStyles(): void {
   // スタイル要素を作成
   const styleElement = document.createElement('style')
   styleElement.id = STYLE_ELEMENT_ID
-  styleElement.textContent = CUSTOM_CSS
+  styleElement.textContent = customCssText
 
   // headまたはbodyに追加
   const target = document.head || document.documentElement

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Plasmo data-text: プレフィックス用の型定義
+ * テキストファイルを文字列としてインポートするための型宣言
+ */
+declare module "data-text:*" {
+  const content: string
+  export default content
+}

--- a/src/styles/notion-custom.css
+++ b/src/styles/notion-custom.css
@@ -31,11 +31,7 @@ div[style*="min-height: 24px"]:has(svg.trash) {
   display: none !important;
 }
 
-/* Sidebar switcher and header */
-.notion-sidebar-switcher {
-  visibility: collapse;
-}
-
+/* Sidebar */
 .notion-outliner-shared-header-container {
   visibility: collapse;
 }


### PR DESCRIPTION
## 概要

notion-simplify.ts内に重複していたCSS定義を削除し、notion-custom.cssファイルのみでスタイルを管理するようリファクタリングしました。また、issue #20に対応して、ワークスペース切り替えボタンの非表示設定を削除しました。

## 変更内容

### 1. CSS管理の一本化
- **notion-simplify.ts**: インラインで定義されていたCSS定義を削除
- **Plasmoの`data-text:`プレフィックス**を使用してnotion-custom.cssを文字列としてインポート
- **global.d.ts**: `data-text:`プレフィックス用のTypeScript型定義を追加

### 2. ワークスペース切り替えボタンの表示 (issue #20対応)
- **notion-custom.css**: `.notion-sidebar-switcher`の非表示設定を削除
- これによりユーザーは複数ワークスペース間を切り替えられるようになります

## メリット

- **保守性向上**: CSSの変更はnotion-custom.cssのみを編集すれば反映される
- **単一責任の原則**: スタイル定義はCSSファイルに集約
- **重複コード削除**: TSファイル内の20行以上のインラインCSSを削除
- **ユーザビリティ改善**: ワークスペース切り替え機能が利用可能に

## テスト

- ✅ ビルドが正常に完了
- ✅ TypeScriptの型エラーなし
- ✅ notion-custom.cssの内容が正しくインポートされることを確認

## 関連issue

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)