### PR TITLE
docs: ドキュメントを現在の実装に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,11 @@ src/
 ├── popup.tsx              # メインエントリーポイント
 ├── screens/               # 画面コンポーネント
 │   ├── HomeScreen.tsx     # ホーム画面
+│   ├── LoginScreen.tsx    # ログイン画面（未認証時に表示）
 │   ├── CreateClipboardScreen.tsx # クリップボード作成画面
 │   ├── ClipboardListScreen.tsx # クリップボード一覧画面
 │   ├── SelectClipboardScreen.tsx # クリップボード選択画面
-│   ├── ClippingProgressScreen.tsx # クリップ進行状況画面
-│   └── SettingsScreen.tsx # 設定画面
+│   └── ClippingProgressScreen.tsx # クリップ進行状況画面
 ├── components/            # 再利用可能コンポーネント
 ├── contents/              # Content Scripts
 │   ├── extract-content.ts # ページコンテンツ抽出
@@ -138,10 +138,12 @@ workers/                   # Cloudflare Workers OAuth バックエンド
 ```typescript
 // Chrome Storage Local
 {
-  'raku-clipboards': Clipboard[],           // クリップボードリスト
-  'raku-notion-config': NotionConfig,       // Notion設定
+  'raku-clipboards': Clipboard[],              // クリップボードリスト
+  'raku-notion-config': NotionConfig,          // Notion設定
   'raku-ui-simplify-config': UISimplifyConfig, // UI簡略化設定
-  'raku-language-config': LanguageConfig    // 言語設定（ja/en）
+  'raku-language-config': LanguageConfig,      // 言語設定（ja/en）
+  'raku-selected-clipboard-id': string,        // 選択中クリップボードID
+  'raku-tag-options-map': Record<string, string[]> // DBごとのタグ候補キャッシュ
 }
 ```
 
@@ -150,7 +152,7 @@ workers/                   # Cloudflare Workers OAuth バックエンド
 詳細は [src/types/index.ts](src/types/index.ts) を参照。
 
 主要な型:
-- `Screen`: 画面タイプ（'home' | 'create-clipboard' | 'clipboard-list' | 'select-clipboard' | 'settings'）
+- `Screen`: 画面タイプ（'home' | 'create-clipboard' | 'clipboard-list' | 'select-clipboard'）
 - `Clipboard`: クリップボード定義
 - `NotionConfig`: Notion認証設定 (OAuth/手動トークン両対応)
 - `WebClipData`: Webクリップデータ
@@ -162,19 +164,17 @@ workers/                   # Cloudflare Workers OAuth バックエンド
 ### 3. 画面遷移フロー
 
 ```
-HomeScreen（起点）
-  ├─ 📎 このページをクリップ（メモ入力可能）
+LoginScreen（未認証時のみ表示）
+  └─ OAuth認証 / 手動トークン入力 → HomeScreen
+
+HomeScreen（起点、認証済み時）
+  ├─ 📎 このページをクリップ（メモ・タグ入力可能）
   │   ├─ (0個) → CreateClipboardScreen
-  │   ├─ (1個) → ClippingProgressScreen → 完了
-  │   └─ (複数) → SelectClipboardScreen → ClippingProgressScreen → 完了
+  │   └─ (1個以上) → ClippingProgressScreen → 完了
   ├─ ClipboardListScreen（クリップボード一覧）
   │   ├─ 登録済みクリップボード表示・削除
   │   └─ 既存データベース取り込み
-  └─ SettingsScreen（⚙️設定）
-      ├─ Notion UI簡略化（有効/無効切り替え）
-      ├─ OAuth認証フロー
-      ├─ 手動トークン入力
-      └─ 内部APIテスト（開発用）
+  └─ 連携解除ボタン → LoginScreen
 ```
 
 **クリップ実行フロー**:
@@ -199,13 +199,13 @@ HomeScreen（起点）
 - 環境変数の扱い: OAuth設定はbackgroundで環境変数から直接取得
 
 **認証フロー**:
-1. SettingsScreen → `start-oauth` メッセージ → backgroundがOAuth URL生成、`raku-oauth-pending: true`を保存
+1. LoginScreen → `start-oauth` メッセージ → backgroundがOAuth URL生成、`raku-oauth-pending: true`を保存
 2. Notion認証画面 → 拡張機能の`oauth-callback.html`にリダイレクト
 3. `oauth-callback.js` → Cloudflare Workersにトークン交換リクエスト（code, state, extensionId）
 4. Workers → Notionにトークン交換リクエスト（CLIENT_SECRETを使用）、アクセストークンを返却
 5. `oauth-callback.js` → backgroundに`complete-oauth`メッセージ（tokenResponseのみ）
 6. backgroundが設定保存、`raku-oauth-pending`削除
-7. SettingsScreenが`chrome.storage.onChanged`で完了を検出、成功メッセージ表示
+7. LoginScreenが`chrome.storage.onChanged`で完了を検出、HomeScreenへ遷移
 
 ### 5. 既存データベース取り込み機能
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ npm run dev
 
 ### 3. Notion連携
 
-1. 拡張機能の設定（⚙️）を開く
-2. 「手動トークン入力」を選択
-3. [Notion Integration](https://www.notion.so/my-integrations) でトークンを作成
-4. トークンを貼り付けて「保存して接続」
+1. 拡張機能を開くとログイン画面が表示されます
+2. 「Notionで認証して接続」を選択
+3. 指示に従ってNotionと拡張機能を接続する
 
 詳細は [docs/SETUP.md](docs/SETUP.md) と [docs/NOTION_AUTH.md](docs/NOTION_AUTH.md) を参照してください。
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,10 +10,10 @@ raku-raku-notion/
 │   ├── popup.tsx              # メインエントリーポイント
 │   ├── screens/               # 画面コンポーネント
 │   │   ├── HomeScreen.tsx
+│   │   ├── LoginScreen.tsx
 │   │   ├── CreateClipboardScreen.tsx
 │   │   ├── ClipboardListScreen.tsx
 │   │   ├── SelectClipboardScreen.tsx
-│   │   ├── SettingsScreen.tsx
 │   │   └── ClippingProgressScreen.tsx
 │   ├── contents/              # Content Scripts
 │   │   ├── extract-content.ts # ページコンテンツ抽出
@@ -67,18 +67,17 @@ raku-raku-notion/
 
 各画面は独立したReactコンポーネントとして実装されています：
 
-- **HomeScreen**: エントリーポイント、クリップボタンとメモ入力
+- **LoginScreen**: ログイン画面（未認証時に表示）、OAuth/手動トークン認証
+- **HomeScreen**: メイン画面（認証済み時）、クリップボタン・メモ・タグ入力、クリップボード選択
 - **CreateClipboardScreen**: クリップボード作成フォーム
 - **ClipboardListScreen**: クリップボード一覧表示＋既存データベース取り込み
-- **SelectClipboardScreen**: クリップ先選択（複数クリップボードがある場合）
-- **SettingsScreen**: Notion認証設定（OAuth/手動トークン）、UI簡略化設定
+- **SelectClipboardScreen**: クリップ先選択（レガシー、現在はHomeScreen内で選択）
 - **ClippingProgressScreen**: クリップ実行中の進行状況表示
 
-画面間の遷移は `popup.tsx` のルーティングロジックで管理されます。
+画面間の遷移は `popup.tsx` のルーティングロジックで管理されます。LoginScreenは認証状態に応じて特別に表示されます。
 
 ```typescript
-export type Screen = 'home' | 'create-clipboard' | 'clipboard-list' |
-                     'select-clipboard' | 'settings'
+export type Screen = 'home' | 'create-clipboard' | 'clipboard-list' | 'select-clipboard'
 ```
 
 ### 2. ビジネスロジック層 (Services)
@@ -339,10 +338,12 @@ SettingsScreen (接続済み表示)
 
 ```typescript
 {
-  'raku-forms': Form[],               // 旧フォームリスト（後方互換）
-  'raku-clipboards': Clipboard[],     // クリップボードリスト
-  'raku-notion-config': NotionConfig, // Notion設定
-  'raku-initialized': boolean         // 初期化フラグ
+  'raku-clipboards': Clipboard[],              // クリップボードリスト
+  'raku-notion-config': NotionConfig,          // Notion設定
+  'raku-ui-simplify-config': UISimplifyConfig, // UI簡略化設定
+  'raku-language-config': LanguageConfig,      // 言語設定（ja/en）
+  'raku-selected-clipboard-id': string,        // 選択中クリップボードID
+  'raku-tag-options-map': Record<string, string[]> // DBごとのタグ候補キャッシュ
 }
 ```
 
@@ -384,19 +385,18 @@ interface NotionDatabaseSummary {
 ## 画面遷移
 
 ```
-HomeScreen
-  ├─> 📎 このページをクリップ
-  │     ├─> (0個) → CreateClipboardScreen
-  │     ├─> (1個) → 自動クリップ
-  │     └─> (複数) → SelectClipboardScreen
+LoginScreen（未認証時のみ）
+  └─> OAuth認証 / 手動トークン → HomeScreen
+
+HomeScreen（認証済み時）
+  ├─> 📎 このページをクリップ → ClippingProgressScreen
+  │     └─> (0個の場合) → CreateClipboardScreen
   ├─> ClipboardListScreen
   │     ├─> Notionデータベースを開く
   │     └─> CreateClipboardScreen
   ├─> CreateClipboardScreen
   │     └─> ClipboardListScreen
-  └─> SettingsScreen
-        ├─> OAuth認証
-        └─> 手動トークン入力
+  └─> 連携解除 → LoginScreen
 ```
 
 ## Notion API連携

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,7 +108,9 @@ const STORAGE_KEYS = {
   NOTION_CONFIG: 'raku-notion-config',
   UI_SIMPLIFY_CONFIG: 'raku-ui-simplify-config',
   LANGUAGE_CONFIG: 'raku-language-config',
-  NEW_DATA: 'raku-new-data', // 追加
+  SELECTED_CLIPBOARD_ID: 'raku-selected-clipboard-id',
+  TAG_OPTIONS_MAP: 'raku-tag-options-map',
+  NEW_DATA: 'raku-new-data', // 追加例
 }
 ```
 


### PR DESCRIPTION
## Summary
- SettingsScreen → LoginScreen への記載を修正
- Screen型から 'settings' を削除し、実装と一致させる
- ストレージキーに `raku-selected-clipboard-id`, `raku-tag-options-map` を追加
- 旧キー（`raku-forms`, `raku-initialized`）の記載を削除
- 画面遷移フローをLoginScreen + HomeScreen構成に更新
- OAuth認証フローの説明をLoginScreen基点に修正

## 修正ファイル
- `CLAUDE.md`
- `README.md`
- `docs/ARCHITECTURE.md`
- `docs/DEVELOPMENT.md`

## Test plan
- [ ] 各ドキュメントの記載が実装ファイル（`src/screens/`, `src/types/index.ts`, `src/services/storage.ts`）と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)