### PR TITLE
削除されたデータベースを一覧から除外

### DIFF
--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -287,7 +287,7 @@ export class NotionService {
       const databases = result.results || []
 
       return databases
-        .filter((item: any) => item.object === "database")
+        .filter((item: any) => item.object === "database" && !item.archived)
         .map((db: any): NotionDatabaseSummary => ({
           id: db.id,
           title: this.getPlainText(db.title) || '無題のデータベース',


### PR DESCRIPTION
## Summary
- listDatabases()でarchived: trueのデータベースをフィルタリング
- ゴミ箱に移動したデータベースが「一覧に登録されていないデータベース」に表示されないように修正

Closes #66