### PR TITLE
OAuth認証完了後にタブを自動的に閉じてUIを開く

### DIFF
--- a/assets/oauth-callback.js
+++ b/assets/oauth-callback.js
@@ -80,23 +80,20 @@
     console.log('[OAuth Callback] Response received:', response)
 
     if (response?.success) {
-      // 成功表示
+      // 成功 - backgroundがタブを閉じてポップアップを開く
+      console.log('[OAuth Callback] Success! Background will close this tab and open popup.')
+
+      // 認証成功メッセージを表示（タブが閉じるまでの短い間）
       const spinnerView = document.getElementById('spinner-view')
-      const successOverlay = document.getElementById('success-overlay')
-      const closeBtn = document.getElementById('close-btn')
-
-      if (spinnerView) spinnerView.style.display = 'none'
-      if (successOverlay) successOverlay.style.display = 'flex'
-
-      console.log('[OAuth Callback] Success! Waiting for user to close...')
-
-      // 閉じるボタンのイベントリスナー
-      if (closeBtn) {
-        closeBtn.onclick = () => {
-          window.close();
-        };
+      if (spinnerView) {
+        spinnerView.innerHTML = `
+          <div style="text-align: center;">
+            <div style="font-size: 48px; margin-bottom: 16px;">✓</div>
+            <div style="color: #4CAF50; font-size: 24px; font-weight: bold; margin-bottom: 8px;">認証成功！</div>
+            <div style="color: #888; font-size: 14px;">このタブは自動的に閉じます...</div>
+          </div>
+        `
       }
-
     } else {
       throw new Error(response?.error || '認証の完了に失敗しました')
     }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -311,8 +311,12 @@ async function handleStartOAuth(
     // OAuth認証URLを生成
     const authUrl = generateOAuthUrl(oauthConfig, state)
 
-    // 新しいタブでOAuth認証画面を開く
-    chrome.tabs.create({ url: authUrl })
+    // 新しいタブでOAuth認証画面を開く（タブIDを保存）
+    const tab = await chrome.tabs.create({ url: authUrl })
+    if (tab.id) {
+      await chrome.storage.local.set({ 'raku-oauth-tab-id': tab.id })
+      console.log('[Background] OAuth tab created with ID:', tab.id)
+    }
 
     // レスポンスを送信（ポップアップがキャッシュされる前に）
     try {
@@ -374,8 +378,10 @@ async function handleCompleteOAuth(
     await StorageService.saveNotionConfig(updatedConfig)
     console.log('[Background] Config saved successfully');
 
-    // OAuth完了フラグを削除
-    await chrome.storage.local.remove(['raku-oauth-state', 'raku-oauth-pending'])
+    // OAuth完了フラグとタブIDを取得してから削除
+    const storageData = await chrome.storage.local.get(['raku-oauth-tab-id'])
+    const oauthTabId = storageData['raku-oauth-tab-id']
+    await chrome.storage.local.remove(['raku-oauth-state', 'raku-oauth-pending', 'raku-oauth-tab-id'])
 
     const response = {
       success: true,
@@ -387,6 +393,34 @@ async function handleCompleteOAuth(
 
     console.log('[Background] Sending success response:', response)
     sendResponse(response)
+
+    // OAuthタブを閉じてUIを開く
+    if (oauthTabId) {
+      try {
+        await chrome.tabs.remove(oauthTabId)
+        console.log('[Background] OAuth tab closed:', oauthTabId)
+      } catch (err) {
+        console.warn('[Background] Failed to close OAuth tab (may already be closed):', err)
+      }
+    }
+
+    // 少し待ってからUIを開く（タブ切り替えの完了を待つ）
+    await new Promise(resolve => setTimeout(resolve, 300))
+
+    // アクティブタブにオーバーレイUIを開く
+    try {
+      await openIframeUiForActiveTab()
+      console.log('[Background] Iframe UI opened successfully after OAuth')
+    } catch (err) {
+      console.warn('[Background] Could not open iframe UI automatically:', err)
+      // フォールバック: action.openPopup を試行
+      try {
+        await chrome.action.openPopup()
+        console.log('[Background] Fallback: Popup opened successfully')
+      } catch (popupErr) {
+        console.warn('[Background] Fallback popup also failed:', popupErr)
+      }
+    }
   } catch (error) {
     console.error("[Background] Failed to complete OAuth:", error)
     sendResponse({


### PR DESCRIPTION
## Summary
- OAuth認証完了後に認証タブを自動的に閉じる
- 閉じた後、アクティブタブに拡張機能のオーバーレイUIを自動的に開く
- コールバックページのオーバーレイを削除し、シンプルな「認証成功！」メッセージに変更

## 変更内容

### src/background/index.ts
- `handleStartOAuth`: OAuthタブのIDをストレージに保存
- `handleCompleteOAuth`: 認証完了後にOAuthタブを閉じ、`openIframeUiForActiveTab()`でUIを自動的に開く

### assets/oauth-callback.js
- 大きなオーバーレイ表示を削除
- シンプルな「認証成功！このタブは自動的に閉じます...」メッセージに変更

## 新しいOAuth認証フロー
```
1. ユーザーが「Notionで認証」クリック
2. background → タブを作成、タブIDを保存
3. ユーザーがNotionで認証
4. コールバックページで「認証成功！」を表示
5. background → 設定保存 → タブを閉じる → オーバーレイUIを開く
```

## Test plan
- [ ] OAuth認証を開始し、Notionで認可する
- [ ] 認証完了後、「認証成功！」メッセージが表示されることを確認
- [ ] 認証タブが自動的に閉じることを確認
- [ ] 元のタブにオーバーレイUIが自動的に表示されることを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)