### PR TITLE
リリースノート生成時にマージコミットを除外

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,10 @@ jobs:
           # 前のタグを取得（なければ最初のコミット）
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || git rev-list --max-parents=0 HEAD)
 
-          # コミットログからリリースノートを生成
+          # コミットログからリリースノートを生成（マージコミットは除外）
           echo "## 変更内容" > RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
-          git log --pretty=format:"- %s" ${PREV_TAG}..HEAD >> RELEASE_NOTES.md
+          git log --no-merges --pretty=format:"- %s" ${PREV_TAG}..HEAD >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "## インストール方法" >> RELEASE_NOTES.md


### PR DESCRIPTION
## 概要
リリースノート自動生成処理でマージコミットを除外するように修正しました。

## 変更内容
- `.github/workflows/release.yml`の`git log`コマンドに`--no-merges`オプションを追加
- これにより「Merge pull request #XX from...」のようなマージコミットがリリースノートから除外されます
- 実際の変更内容を含むコミットのみがリリースノートに記載されるようになります

## 影響範囲
- リリースノート生成処理のみ
- 既存のリリースには影響なし

## テスト計画
- 次回のリリースタグ作成時に、生成されるリリースノートにマージコミットが含まれていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)